### PR TITLE
Chore - Modified .gitignore to exlude the compiled typescript files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,9 +60,6 @@ buck-out/
 android/app/libs
 android/keystores/debug.keystore
 
-# Expo
-.expo/
-
 # Turborepo
 .turbo/
 
@@ -73,3 +70,8 @@ docs/API/.nojekyll
 
 *.metallib
 .xocde.env.local
+
+# Compiled Typescript files
+src/**/*.js
+example/**/*.js
+


### PR DESCRIPTION
Removed all the generated .js files from the .gitignore as they were starting to get annoying. 

Also removed a duplicated ignore of .expo/