### PR TITLE
Removed "importsNotUsedAsValues" from app.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
-    "importsNotUsedAsValues": "error",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "lib": ["esnext"],


### PR DESCRIPTION
This was causing errors, especially when running `tsc`.

This was made relevant as we no longer include generated JS files in git